### PR TITLE
Add check for root and toor (for BSD) and change user symbol accordingly

### DIFF
--- a/src/handler.py
+++ b/src/handler.py
@@ -16,7 +16,12 @@ class shell():
         return out
 
     def userinput(self, ps1):
-        prompt = ps1.format(self.getFormattedCWD(), getpass.getuser()) #Formats {0} to the current directory and {1} to the current user.
+        print(getpass.getuser())
+        if getpass.getuser() in ["root", "toor"]:
+            usrsym = "#"
+        else:
+            usrsym = "$"
+        prompt = ps1.format(self.getFormattedCWD(), usrsym) #Formats {0} to the current directory and {1} to the current user.
         data = input(prompt)
         self.process(data)
 

--- a/src/handler.py
+++ b/src/handler.py
@@ -16,7 +16,6 @@ class shell():
         return out
 
     def userinput(self, ps1):
-        print(getpass.getuser())
         if getpass.getuser() in ["root", "toor"]:
             usrsym = "#"
         else:

--- a/src/pell.py
+++ b/src/pell.py
@@ -12,6 +12,6 @@ sh = handler.shell()
 
 while 1:
     try:
-        sh.userinput("pell {0} $ ")
+        sh.userinput("pell {0} {1} ")
     except (KeyboardInterrupt, EOFError) as e:
         print("")


### PR DESCRIPTION
This will check if the user is `root` or `toor` and change the user to `#` if they are superuser. If not it will leave it as `$`.

Checking if the uid is 0 would probably be a better method but this works just as well. As far as I'm aware, there are no other Unix-based operating systems that don't use anything other than `root` or `toor` for uid 0
